### PR TITLE
Add request attributes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.html
 *.ts
 *.mp4
+.idea/

--- a/connection.go
+++ b/connection.go
@@ -216,6 +216,8 @@ type srtConn struct {
 	// HSv4
 	stopHSRequests context.CancelFunc
 	stopKMRequests context.CancelFunc
+
+	requestAttributes RequestAttributes
 }
 
 type srtConnConfig struct {
@@ -236,6 +238,7 @@ type srtConnConfig struct {
 	onSend                      func(p packet.Packet)
 	onShutdown                  func(socketId uint32)
 	logger                      Logger
+	attrs                       RequestAttributes
 }
 
 func newSRTConn(config srtConnConfig) *srtConn {
@@ -257,6 +260,7 @@ func newSRTConn(config srtConnConfig) *srtConn {
 		onSend:                      config.onSend,
 		onShutdown:                  config.onShutdown,
 		logger:                      config.logger,
+		requestAttributes:           config.attrs,
 	}
 
 	if c.onSend == nil {
@@ -360,6 +364,10 @@ func newSRTConn(config srtConnConfig) *srtConn {
 	}
 
 	return c
+}
+
+func (c *srtConn) GetRequestAttributes() RequestAttributes {
+	return c.requestAttributes
 }
 
 func (c *srtConn) LocalAddr() net.Addr {

--- a/contrib/server/main.go
+++ b/contrib/server/main.go
@@ -147,6 +147,8 @@ func (s *server) handleConnect(req srt.ConnRequest) srt.ConnType {
 
 	channel := ""
 
+	attrs := srt.GetRequestAttributes(req)
+
 	if req.Version() == 4 {
 		mode = srt.PUBLISH
 		channel = "/" + client.String()
@@ -212,6 +214,9 @@ func (s *server) handleConnect(req srt.ConnRequest) srt.ConnType {
 		return srt.REJECT
 	}
 
+	attrs.Set("channel", channel)
+	attrs.Set("address", client)
+
 	return mode
 }
 
@@ -222,6 +227,9 @@ func (s *server) handlePublish(conn srt.Conn) {
 		conn.Close()
 		return
 	}
+
+	attrs := srt.GetRequestAttributes(conn)
+	s.log("PUBLISH", "PUBLISH", attrs.GetValue("channel").(string), "client will publish", attrs.GetValue("address").(net.Addr))
 
 	if conn.Version() == 4 {
 		channel = "/" + client.String()

--- a/request_attributes.go
+++ b/request_attributes.go
@@ -1,0 +1,51 @@
+package srt
+
+// RequestAttributes Allows passing data from connection handler to publish and subscribe handlers
+type RequestAttributes interface {
+	// Get Returns value stored using the given key, returns true if found otherwise false
+	Get(key string) (any, bool)
+
+	// GetValue returns the value stored using the given key. If the value does not exist then nil is returned.
+	// Unlike the `Get` function, this function does not return any indication that the returned nil is the actual
+	// retrieved value or not.
+	GetValue(key string) any
+
+	// Set Sets attribute
+	Set(key string, value any)
+
+	// Has Checks if attribute set contains given key
+	Has(key string) bool
+}
+
+type connRequestAttributes struct {
+	attrs map[string]any
+}
+
+func (c *connRequestAttributes) Get(key string) (any, bool) {
+	v, ok := c.attrs[key]
+	return v, ok
+}
+
+func (c *connRequestAttributes) GetValue(key string) any {
+	return c.attrs[key]
+}
+
+func (c *connRequestAttributes) Set(key string, value any) {
+	c.attrs[key] = value
+}
+
+func (c *connRequestAttributes) Has(key string) bool {
+	_, ok := c.attrs[key]
+	return ok
+}
+
+type AttributeContainer interface {
+	GetRequestAttributes() RequestAttributes
+}
+
+func GetRequestAttributes(t any) RequestAttributes {
+	if ra, ok := t.(AttributeContainer); ok {
+		return ra.GetRequestAttributes()
+	}
+	return nil
+}


### PR DESCRIPTION
This commit adds the ability to forward request data from the `HandleConnect` handler to `HandleSubscribe` and `HandlePublish` handlers, through the use of request attributes. 

This is a non-breaking change and maintains backwards compatibility.